### PR TITLE
fix(workflows): 修复check file size检查报错问题

### DIFF
--- a/.github/workflows/check_file_size.yml
+++ b/.github/workflows/check_file_size.yml
@@ -84,8 +84,8 @@ jobs:
             
             ---
             
-            <small>温馨提示: 您可以直接使用 `/auto-fix` 命令来自动修复这些文件。</small>
-            <small>Warm reminder: You can use the `/auto-fix` command to automatically fix these files.</small>
+            <small>温馨提示: 您可以直接使用 \`/auto-fix\` 命令来自动修复这些文件。</small>
+            <small>Warm reminder: You can use the \`/auto-fix\` command to automatically fix these files.</small>
               `.trim();
 
               await github.rest.issues.createComment({


### PR DESCRIPTION
## 描述

`check_file_size.yml` 会检查贡献者提交的所有文件大小, 并且进入不同的处理分支

过去大家的提交都比较规范, 文件大小均小于1MiB, 所以未报错, 我第一次观察到报错是在[#383](https://github.com/Cute-Dress/Dress/pull/383)中

```shell
Error: Unhandled error: ReferenceError: auto is not defined
```

问题所在: 当检查到大于1MiB的文件进入 `if (oversized.length > 0) { ... }` 分支后, 因为模板字符串中直接包含未转义的 `` `/auto-fix` ``, 反引号提前结束了字符串，导致 `/auto-fix` 被解析为表达式 `auto - fix`

## 复现

在本地的复现结果如下:

```shell
# reproduce the bug
node <<'NODE'
const oversized = ['file.png (1200000 bytes)'];
const body = `
我们注意到以下文件的大小超过了 1MB, 请在压缩后再次提交 Pull Request:
We have noted that the following files exceed 1MB in size. Please resubmit your pull request after compressing them:

${oversized.join("\n")}

---

<small>温馨提示: 您可以直接使用 `/auto-fix` 命令来自动修复这些文件。</small>
<small>Warm reminder: You can use the `/auto-fix` command to automatically fix these files.</small>
  `.trim();
console.log(body);
NODE
```

Output:

```shell
[stdin]:10
<small>温馨提示: 您可以直接使用 `/auto-fix` 命令来自动修复这些文件。</small>
                       ^

ReferenceError: auto is not defined
    at [stdin]:10:24
    at runScriptInThisContext (node:internal/vm:219:10)
    ...
```

## 测试

修复后进行的本地测试:

```shell
# verify the fix
node <<'NODE'
const oversized = ['file.png (1200000 bytes)'];
const body = `
我们注意到以下文件的大小超过了 1MB, 请在压缩后再次提交 Pull Request:
We have noted that the following files exceed 1MB in size. Please resubmit your pull request after compressing them:

${oversized.join("\n")}

---

<small>温馨提示: 您可以直接使用 \`/auto-fix\` 命令来自动修复这些文件。</small>
<small>Warm reminder: You can use the \`/auto-fix\` command to automatically fix these files.</small>
  `.trim();
console.log(body);
NODE
```

Output:

```shell
我们注意到以下文件的大小超过了 1MB, 请在压缩后再次提交 Pull Request:
We have noted that the following files exceed 1MB in size. Please resubmit your pull request after compressing them:

file.png (1200000 bytes)

---

<small>温馨提示: 您可以直接使用 `/auto-fix` 命令来自动修复这些文件。</small>
<small>Warm reminder: You can use the `/auto-fix` command to automatically fix these files.</small>
```

