### PR TITLE
fix(.github): 修改与readme描述不符的template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,5 +18,5 @@ You can also check [merged PRs](https://github.com/Cute-Dress/Dress/pulls?q=is%3
 
 - [ ] 图片已压缩至 1MB 以内 / Images are compressed to under 1MB
 - [ ] 已移除图片中的 EXIF 信息（参考 [CONTRIBUTING.md](CONTRIBUTING.md)）/ EXIF data has been removed from images (see [CONTRIBUTING.md](CONTRIBUTING.md))
-- [ ] 文件夹以 GitHub ID 命名，并放在对应首字母目录下 / Folder is named after my GitHub ID and placed under the correct alphabetical directory
+ - [ ] 文件夹按首字母归类且不会影响排序（无需强制使用 GitHub ID） / Folder is placed under the correct alphabetical directory and doesn't affect sorting (GitHub ID not required)
 - [ ] 图片为本人原创，未盗用他人作品 / Images are original and not stolen from others


### PR DESCRIPTION
模板原文为:

```text
- [ ] 文件夹以 GitHub ID 命名，并放在对应首字母目录下 / Folder is named after my GitHub ID and placed under the correct alphabetical directory
```

但其实 README 并没有要求的这么严格, 我觉得为了方便大家可以放开限制
