### PR TITLE
docs: 将部分克隆调整为可选方案

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -46,14 +46,27 @@ Fork 仓库 → 添加你的照片 → 提交 Commit → 发起 Pull Request →
 > **Push** = 把本地的 Commit 上传同步到远程仓库（你的 Fork）。  
 
 ```bash
-# 1. 部分克隆你 Fork 的仓库
-#    仅下载最新提交和目录结构，照片会在选择目录后按需下载
+# 1. 克隆你 Fork 的仓库
+# 由于仓库 commit 历史较多，使用 --depth 1 仅拉取最近一次提交
+git clone --depth 1 https://github.com/<你的用户名>/Dress.git
+cd Dress
+```
+
+如果你觉得仓库图片较多、普通克隆太慢，可以使用部分克隆代替上面的命令，只下载自己的目录：
+
+```bash
 git clone --filter=blob:none --sparse --depth 1 https://github.com/<你的用户名>/Dress.git
 cd Dress
-
-# 2. 只检出你的目录，再创建文件夹并添加照片
-#    路径需要加引号；数字或符号开头时使用 # 目录
 git sparse-checkout set '<首字母>/<你的文件夹名>'
+```
+
+部分克隆不会影响正常提交和 PR。目录管理、完整历史和恢复完整仓库的方法请阅读[部分克隆指南](PARTIAL_CLONE.md)。
+
+克隆完成后，创建你的文件夹并添加照片：
+
+```bash
+# 2. 创建你的文件夹并添加照片
+# <首字母> 应与 <你的文件夹名> 的首字符对应；数字或符号开头时使用 #
 mkdir -p <首字母>/<你的文件夹名>
 cp /path/to/your/photos/* <首字母>/<你的文件夹名>/
 
@@ -64,8 +77,6 @@ git commit -m "Add photos for <你的文件夹名>"
 # 4. 推送到你的 Fork
 git push origin main
 ```
-
-部分克隆不会影响正常提交和 PR，但默认不下载其他贡献者的照片。目录管理、完整历史和恢复完整仓库的方法请阅读[部分克隆指南](PARTIAL_CLONE.md)。
 
 ---
 

--- a/en-US/GUIDE.md
+++ b/en-US/GUIDE.md
@@ -45,14 +45,27 @@ Fork repo → Add your photos → Commit → Open Pull Request → Wait for revi
 > **Push** = Uploading your local commits back to the remote repository (your Fork).
 
 ```bash
-# 1. Partially clone your fork
-#    Download only the latest commit and directory structure; photos are fetched on demand
+# 1. Clone your fork
+# The repository has a long commit history, so --depth 1 fetches only the latest commit
+git clone --depth 1 https://github.com/<Your username>/Dress.git
+cd Dress
+```
+
+If the repository's images make a regular clone too slow, use a partial clone instead of the commands above to download only your directory:
+
+```bash
 git clone --filter=blob:none --sparse --depth 1 https://github.com/<Your username>/Dress.git
 cd Dress
-
-# 2. Check out only your directory, then create it and add photos
-#    Quote the path; use the # directory for a name starting with a number or symbol
 git sparse-checkout set '<FirstLetter>/<YourFolderName>'
+```
+
+A partial clone works with normal commits and pull requests. See the [Partial Clone Guide](PARTIAL_CLONE.md) to manage directories, fetch complete history, or restore the full repository.
+
+After cloning, create your folder and add photos:
+
+```bash
+# 2. Create your folder and add photos
+# <FirstLetter> must match the first character of <YourFolderName>; use # for a number or symbol
 mkdir -p <FirstLetter>/<YourFolderName>
 cp /path/to/your/photos/* <FirstLetter>/<YourFolderName>/
 
@@ -63,8 +76,6 @@ git commit -m "Add photos for <YourFolderName>"
 # 4. Push to your fork
 git push origin main
 ```
-
-A partial clone works with normal commits and pull requests, but it does not download other contributors' photos by default. See the [Partial Clone Guide](PARTIAL_CLONE.md) to manage directories, fetch complete history, or restore the full repository.
 
 ---
 


### PR DESCRIPTION
<!-- pr-type: docs -->
<!-- 请勿删除以上 pr-type 行 -->

**PR 类型**：文档修改

**改动描述**：

根据 [Yueosa 在 #436 的评论](https://github.com/Cute-Dress/Dress/pull/436#issuecomment-5305899744) 调整新手指南中的克隆流程：

- 恢复 `git clone --depth 1` 作为命令行贡献的主流程
- 将部分克隆调整为普通克隆过慢时的可选方案
- 保留独立的部分克隆指南，并同步修改中英文 `GUIDE.md`

### 自查

- [x] 本次 PR 以文档/说明为主，不含需要入库的女装照片
- [x] 链接与路径已核对